### PR TITLE
[CN/JP] Include keywords from description before upgrade

### DIFF
--- a/src/main/java/mintySpire/patches/cards/betterUpdatePreview/CardFields.java
+++ b/src/main/java/mintySpire/patches/cards/betterUpdatePreview/CardFields.java
@@ -6,12 +6,15 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 public class CardFields {
     @SpirePatch(clz = AbstractCard.class, method = SpirePatch.CLASS)
     public static class AbCard {
         public static SpireField<String> defaultText = new SpireField<>(() -> "");
         public static SpireField<String> upgradedText = new SpireField<>(() -> "");
+        public static SpireField<Set<String>> keywordSet = new SpireField<>(HashSet::new);
         public static SpireField<String> diffText = new SpireField<>(() -> "");
         public static SpireField<Boolean> isInDiffRmv = new SpireField<>(() -> false);
         public static SpireField<Boolean> isInDiffAdd = new SpireField<>(() -> false);

--- a/src/main/java/mintySpire/patches/cards/betterUpdatePreview/SetTextFieldsPatches.java
+++ b/src/main/java/mintySpire/patches/cards/betterUpdatePreview/SetTextFieldsPatches.java
@@ -15,6 +15,7 @@ import mintySpire.MintySpire;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,6 +31,9 @@ public class SetTextFieldsPatches {
         @SpirePostfixPatch
         public static void defaultAndUpgradedText(AbstractCard _instance) {
             if (MintySpire.showBCUP()) {
+                if (Settings.lineBreakViaCharacter) {
+                    CardFields.AbCard.keywordSet.get(_instance).addAll(_instance.keywords);
+                }
                 if (_instance.upgraded) {
                     CardFields.AbCard.upgradedText.set(_instance, _instance.rawDescription);
                 } else {
@@ -73,7 +77,7 @@ public class SetTextFieldsPatches {
             if (!Settings.lineBreakViaCharacter) {
                 builder.inlineDiffBySplitter(SetTextFieldsPatches::splitter);
             } else {
-                builder.inlineDiffBySplitter(createSplitterCN(card.keywords));
+                builder.inlineDiffBySplitter(createSplitterCN(CardFields.AbCard.keywordSet.get(card)));
             }
             DiffRowGenerator generator = builder.build();
             List<DiffRow> rows = generator.generateDiffRows(Collections.singletonList(original), Collections.singletonList(upgraded));
@@ -87,7 +91,7 @@ public class SetTextFieldsPatches {
                 if (!Settings.lineBreakViaCharacter) {
                     builder.inlineDiffBySplitter(SetTextFieldsPatches::splitter);
                 } else {
-                    builder.inlineDiffBySplitter(createSplitterCN(card.keywords));
+                    builder.inlineDiffBySplitter(createSplitterCN(CardFields.AbCard.keywordSet.get(card)));
                 }
                 generator = builder.build();
                 rows = generator.generateDiffRows(Collections.singletonList(original), Collections.singletonList(upgraded));
@@ -112,7 +116,7 @@ public class SetTextFieldsPatches {
         return ret;
     }
 
-    private static Function<String, List<String>> createSplitterCN(List<String> keywords) {
+    private static Function<String, List<String>> createSplitterCN(Set<String> keywords) {
         Pattern splitBySpaces = Pattern.compile("(?<=\\s)(?=[^\\s])");
         Pattern asciiChars = Pattern.compile("[\\x00-\\x7F]+");
         Pattern splitByAsciiAndNonAscii = Pattern.compile("(?<=[^\\x00-\\x7F])(?=[\\x00-\\x7F])|(?<=[\\x00-\\x7F])(?=[^\\x00-\\x7F])");


### PR DESCRIPTION
`card.keywords` contains only keywords from upgraded description. Sometimes keywords change after upgrading. This may cause problem if a keyword is replaced with a non-keyword. Here's an example. Say "XYZ" is the keyword:

```
Before upgrade: AB XYZ C -> A|B|XYZ|C
After upgrade:  ABXWUC -> A|B|X|W|U|C
```
The difference is "WU" now, because XYZ is not considered as a keyword when comparing texts. Since XYZ is a keyword, it makes more sense that XWU is the difference.