### PR TITLE
Changing RelicAffectionPatch for Pennib and Necronomicon

### DIFF
--- a/src/main/java/mintySpire/patches/cards/RelicAffectionPatch.java
+++ b/src/main/java/mintySpire/patches/cards/RelicAffectionPatch.java
@@ -104,7 +104,7 @@ public class RelicAffectionPatch {
 
             if (cardFields.isPenAff.get(card) && combatCheck()) {
                 pNib.counter = -1;
-                pNib.currentX = card.current_x + (390.0f + (numRelics*pNib.img.getWidth())) * card.drawScale / 3.0f * Settings.scale;
+                pNib.currentX = card.current_x + 390.0f * card.drawScale / 3.0f * Settings.scale - AbstractRelic.PAD_X * 0.5f * numRelics * card.drawScale;
                 pNib.currentY = card.current_y + 546.0f * card.drawScale / 3.0f * Settings.scale;
                 pNib.scale = card.drawScale;
                 pNib.renderOutline(sb, false);

--- a/src/main/java/mintySpire/patches/cards/RelicAffectionPatch.java
+++ b/src/main/java/mintySpire/patches/cards/RelicAffectionPatch.java
@@ -96,7 +96,7 @@ public class RelicAffectionPatch {
             if (cardFields.isNecroAff.get(card) && combatCheck()) {
                 nCon.currentX = card.current_x + 390.0f * card.drawScale / 3.0f * Settings.scale;
                 nCon.currentY = card.current_y + 546.0f * card.drawScale / 3.0f * Settings.scale;
-                nCon.scale = card.drawScale;
+                nCon.scale = card.drawScale * Settings.scale;
                 nCon.renderOutline(sb, false);
                 nCon.render(sb);
                 numRelics++;
@@ -104,9 +104,9 @@ public class RelicAffectionPatch {
 
             if (cardFields.isPenAff.get(card) && combatCheck()) {
                 pNib.counter = -1;
-                pNib.currentX = card.current_x + 390.0f * card.drawScale / 3.0f * Settings.scale - AbstractRelic.PAD_X * 0.5f * numRelics * card.drawScale;
-                pNib.currentY = card.current_y + 546.0f * card.drawScale / 3.0f * Settings.scale;
-                pNib.scale = card.drawScale;
+                pNib.currentX = card.current_x + 390.0f * card.drawScale / 3.0f * Settings.scale;
+                pNib.currentY = card.current_y + 546.0f * card.drawScale / 3.0f * Settings.scale - AbstractRelic.PAD_X * 0.7f * numRelics * card.drawScale;
+                pNib.scale = card.drawScale * Settings.scale;
                 pNib.renderOutline(sb, false);
                 pNib.render(sb);
                 //numRelics++;


### PR DESCRIPTION
This primarily fixes two things:

!. Relic Size not scaling correctly when on cards (becoming much bigger or smaller than they should be)
2. Pen Nib floating off the card (and slightly overlapping) when both Necronomicon and Pennib are affecting the same card, which made it look awkward.

Before:
<img width="107" height="74" alt="image" src="https://github.com/user-attachments/assets/be930df5-cde5-4543-82d9-8766303cca7c" />
After:
<img width="125" height="164" alt="image" src="https://github.com/user-attachments/assets/18f78f11-3e3c-4930-bc4c-e05705e81683" />
